### PR TITLE
Add Unity generator spawn support

### DIFF
--- a/packages/core/src/generators/unity/index.ts
+++ b/packages/core/src/generators/unity/index.ts
@@ -268,3 +268,15 @@ public class MythManager : MonoBehaviour
     }` : '// No quest methods defined'}
 }`;
 }
+
+/**
+ * Spawn the Unity generator as a separate asynchronous task.
+ * Currently this simply calls {@link generateUnityProject}.
+ */
+export async function spawnUnityGenerator(
+  seed: SeedConfig,
+  outputDir: string,
+  verbose: boolean = false
+): Promise<void> {
+  await generateUnityProject(seed, outputDir, verbose);
+}

--- a/packages/core/src/standalone.ts
+++ b/packages/core/src/standalone.ts
@@ -578,3 +578,4 @@ async function generateDocsProject(seedData: any, outputDir: string, verbose: bo
   }
   return [];
 }
+export { spawnUnityGenerator } from './generators/unity/index.js';

--- a/test/core/unitySpawn.test.ts
+++ b/test/core/unitySpawn.test.ts
@@ -1,0 +1,8 @@
+import { describe, it, expect } from 'vitest';
+import { spawnUnityGenerator } from '../../packages/core/src/standalone.js';
+
+describe('spawnUnityGenerator export', () => {
+  it('should be a function', () => {
+    expect(typeof spawnUnityGenerator).toBe('function');
+  });
+});


### PR DESCRIPTION
## Summary
- implement `spawnUnityGenerator` in Unity generator
- export the spawn function from the standalone entry
- test that `spawnUnityGenerator` is exported

## Testing
- `npx vitest run` *(fails: dependencies not installed)*

------
https://chatgpt.com/codex/tasks/task_e_683c05d3ca748328b821df91b96329b9