### PR TITLE
Add additional seed examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,11 @@ $ pnpm dev
 
 # 5 — Open http://localhost:3000 to explore the generated realm
 ```
+### 3.4 Seed Examples
+- `seeds/forest-guardian.yaml`
+- `seeds/mystic-tower.yaml`
+- `seeds/ocean-depths.yaml`
+
 
 ### 3.3 Docker (Optional)
 ```bash

--- a/seeds/mystic-tower.yaml
+++ b/seeds/mystic-tower.yaml
@@ -1,0 +1,33 @@
+world:
+  name: "Mystic Tower"
+  description: "A towering spire filled with arcane secrets and magical traps"
+  theme: "arcane_mystery"
+
+entities:
+  - type: guardian
+    name: "Arcana Sentinel"
+    description: "A construct of pure magic guarding the tower's heart"
+    location: "grand_library"
+    abilities:
+      - "arcane_blast"
+      - "teleport"
+      - "spell_shield"
+
+locations:
+  - name: "grand_library"
+    description: "A vast hall of floating tomes and shifting staircases"
+    connections:
+      - "astral_observatory"
+
+  - name: "astral_observatory"
+    description: "A dome where stars align to fuel ancient rituals"
+    connections:
+      - "grand_library"
+      - "sealed_chamber"
+
+interactions:
+  - trigger: "enter_library"
+    type: "dialogue"
+    responses:
+      - "Knowledge has a price. Are you willing to pay?"
+      - "The sentinel's eyes glow with unspoken warnings."

--- a/seeds/ocean-depths.yaml
+++ b/seeds/ocean-depths.yaml
@@ -1,0 +1,33 @@
+world:
+  name: "Ocean Depths"
+  description: "A submerged realm of glowing ruins and lurking leviathans"
+  theme: "aquatic_ruins"
+
+entities:
+  - type: guardian
+    name: "Tidewatcher"
+    description: "An ancient sea spirit that guides lost sailors"
+    location: "sunken_temple"
+    abilities:
+      - "tidal_wave"
+      - "water_breath"
+      - "currents_call"
+
+locations:
+  - name: "sunken_temple"
+    description: "Collapsed pillars where water currents whisper forgotten prayers"
+    connections:
+      - "kelp_forest"
+
+  - name: "kelp_forest"
+    description: "Towering fronds sway in the deep, concealing hidden dangers"
+    connections:
+      - "sunken_temple"
+      - "abyssal_trench"
+
+interactions:
+  - trigger: "seek_spirit"
+    type: "dialogue"
+    responses:
+      - "The tides speak through me. What do you seek?"
+      - "Bubbles rise as the guardian gestures toward the darkened trench."


### PR DESCRIPTION
## Summary
- add new sample seeds `mystic-tower` and `ocean-depths`
- document available seed examples in the README

## Testing
- `pnpm test` *(fails: unsupported pnpm version)*
- `npx vitest run` *(fails: network access blocked)*

------
https://chatgpt.com/codex/tasks/task_e_683bf8358c2c8328a7bc68998d7c3887